### PR TITLE
fix: 修复inula-request请求头重复添加Content—Type的问题

### DIFF
--- a/.changeset/little-suns-matter.md
+++ b/.changeset/little-suns-matter.md
@@ -1,0 +1,5 @@
+---
+"inula-request": patch
+---
+
+fix: 修复inula-request请求头重复添加Content—Type的问题

--- a/packages/inula-request/package.json
+++ b/packages/inula-request/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inula-request",
-  "version": "1.1.5",
+  "version": "1.1.7",
   "description": "Inula-request brings you a convenient request experience!",
   "type": "module",
   "main": "./dist/inulaRequest.esm-browser.js",

--- a/packages/inula-request/src/dataTransformers/transformRequest.ts
+++ b/packages/inula-request/src/dataTransformers/transformRequest.ts
@@ -27,24 +27,28 @@ const strategies: Record<string, Strategy> = {
   FormData: (data, headers, hasJSONContentType: boolean) => {
     return hasJSONContentType ? JSON.stringify(getJSONByFormData(data)) : data;
   },
-  StreamOrFileOrBlob: (data, headers) => {
+  StreamOrFileOrBlob: data => {
     return data;
   },
   URLSearchParams: (data, headers) => {
-    headers['Content-Type'] = headers['Content-type'] ?? 'application/x-www-form-urlencoded;charset=utf-8';
+    if (!headers.has('Content-Type')) {
+      headers.set('Content-Type', 'application/x-www-form-urlencoded;charset=utf-8');
+    }
     return data.toString();
   },
   MultipartFormData: (data, headers, isFileList: boolean) => {
     return getFormData(isFileList ? { 'files[]': data } : data);
   },
   JSONData: (data, headers) => {
-    headers['Content-Type'] = headers['Content-Type'] ?? 'application/json';
+    if (!headers.has('Content-Type')) {
+      headers.set('Content-Type', 'application/json');
+    }
     return utils.stringifySafely(data);
   },
 };
 
 function transformRequest(data: any, headers: IrHeaders): any {
-  const contentType = headers['Content-Type'] || '';
+  const contentType = headers.get('Content-Type') || '';
   const hasJSONContentType = contentType.indexOf('application/json') > -1;
   const isObjectPayload = utils.checkObject(data);
 

--- a/packages/inula-request/src/types/interfaces.ts
+++ b/packages/inula-request/src/types/interfaces.ts
@@ -15,7 +15,7 @@
 
 import IrError from '../core/IrError';
 import IrHeaders from '../core/IrHeaders';
-import { Method, ResponseType, IrTransformer, FulfilledFn, RejectedFn, Callback } from './types';
+import { Method, ResponseType, FulfilledFn, RejectedFn, Callback } from './types';
 import CancelError from '../cancel/CancelError';
 import { CanceledError } from '../../index';
 

--- a/packages/inula-request/src/utils/commonUtils/utils.ts
+++ b/packages/inula-request/src/utils/commonUtils/utils.ts
@@ -145,8 +145,7 @@ function forEach<T>(
 function getObjectKey<T>(obj: Record<string, T>, key: string): string | null {
   const _key = key.toLowerCase();
   const keys = Object.keys(obj);
-  for (let i = 0; i < keys.length; i++) {
-    const k = keys[i];
+  for (const k of keys.reverse()) {
     if (k.toLowerCase() === _key) {
       return k;
     }

--- a/packages/inula-request/src/utils/commonUtils/utils.ts
+++ b/packages/inula-request/src/utils/commonUtils/utils.ts
@@ -145,7 +145,8 @@ function forEach<T>(
 function getObjectKey<T>(obj: Record<string, T>, key: string): string | null {
   const _key = key.toLowerCase();
   const keys = Object.keys(obj);
-  for (const k of keys.reverse()) {
+  for (let i = keys.length - 1; i >= 0; i--) {
+    const k = keys[i];
     if (k.toLowerCase() === _key) {
       return k;
     }

--- a/packages/inula/src/inulax/adapters/utils.ts
+++ b/packages/inula/src/inulax/adapters/utils.ts
@@ -99,7 +99,7 @@ export default function transferNonInulaStatics<T extends ComponentType<any>, S 
           try {
             // 将属性描述符应用到目标组件
             defineProperty(target, key, descriptor);
-          } catch {
+          } catch (_) {
             // 忽略错误
           }
         }


### PR DESCRIPTION
fix: 修复inula-request请求头重复添加Content—Type的问题
close #36 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved response header handling for more consistent and streamlined processing.
	- Simplified header normalization and merging logic for better reliability.
	- Updated internal strategies to use a unified header interface for setting and retrieving headers.
	- Enhanced utility function for object key retrieval to search in reverse order.
- **Style**
	- Minor code style adjustment for error handling in utility functions.
- **Bug Fixes**
	- Resolved issue preventing duplicate "Content-Type" headers in HTTP requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->