### PR TITLE
feat: inula-request add redirect support; tweak openinula peerDependencies version

### DIFF
--- a/.changeset/lucky-bikes-cross.md
+++ b/.changeset/lucky-bikes-cross.md
@@ -1,0 +1,5 @@
+---
+"inula-request": patch
+---
+
+feat: inula-request add redirect support; tweak openinula peerDependencies version

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "rollup-plugin-terser": "^7.0.2",
     "ts-jest": "^29.1.1",
     "turbo": "^2.4.2",
-    "typescript": "^4.9.5"
+    "typescript": "~5.5.4"
   },
   "engines": {
     "node": ">=10.x",

--- a/packages/inula-intl/package.json
+++ b/packages/inula-intl/package.json
@@ -24,7 +24,7 @@
   "author": "",
   "license": "MulanPSL2",
   "peerDependencies": {
-    "openinula": ">=0.1.14"
+    "openinula": ">=0.0.1"
   },
   "devDependencies": {
     "@babel/preset-react": "^7.9.4",

--- a/packages/inula-request/package.json
+++ b/packages/inula-request/package.json
@@ -53,7 +53,7 @@
     "webpack-dev-server": "^4.13.3"
   },
   "peerDependencies": {
-    "openinula": ">=0.1.14"
+    "openinula": ">=0.0.1"
   },
   "exclude": [
     "node_modules"

--- a/packages/inula-request/src/core/IrHeaders.ts
+++ b/packages/inula-request/src/core/IrHeaders.ts
@@ -216,7 +216,7 @@ class IrHeaders {
     otherItems.forEach(item => newHeaders.set(item));
 
     // 删除值为 undefined 请求头， fetch 进行自动配置
-    for (const key in Object.keys(newHeaders)) {
+    for (const key of Object.keys(newHeaders)) {
       const headerValue = newHeaders[key];
       if (headerValue === undefined || headerValue === null) {
         newHeaders.delete(key);

--- a/packages/inula-request/src/request/fetchRequest.ts
+++ b/packages/inula-request/src/request/fetchRequest.ts
@@ -36,6 +36,7 @@ export const fetchRequest = (config: IrRequestConfig): Promise<IrResponse> => {
       onUploadProgress = null,
       onDownloadProgress = null,
       paramsSerializer,
+      fetchOption,
     } = config;
 
     let { signal, url, data = null } = config;
@@ -50,6 +51,7 @@ export const fetchRequest = (config: IrRequestConfig): Promise<IrResponse> => {
       headers,
       body: data || null, // 防止用户在拦截器传入空字符串，引发 fetch 错误
       credentials: withCredentials ? 'include' : 'omit',
+      ...fetchOption,
     };
 
     if (typeof window !== 'undefined' && window.AbortController) {
@@ -108,6 +110,7 @@ export const fetchRequest = (config: IrRequestConfig): Promise<IrResponse> => {
           config.method = config.method!.toLowerCase() as Method;
 
           const responseData: IrResponse = {
+            type: response.type,
             data: '',
             status: response.status,
             statusText: response.statusText,

--- a/packages/inula-request/src/request/ieFetchRequest.ts
+++ b/packages/inula-request/src/request/ieFetchRequest.ts
@@ -91,6 +91,7 @@ export const ieFetchRequest = (config: IrRequestConfig): Promise<IrResponse> => 
         config.method = config.method!.toLowerCase() as Method;
 
         const responseData: IrResponse = {
+          type: 'default',
           data: '',
           status: response.status,
           statusText: response.statusText,

--- a/packages/inula-request/src/request/processUploadProgress.ts
+++ b/packages/inula-request/src/request/processUploadProgress.ts
@@ -22,25 +22,12 @@ function processUploadProgress(
   onUploadProgress: (progressEvent: IrProgressEvent) => void,
   data: FormData,
   reject: (reason?: any) => void,
-  resolve: (value: PromiseLike<IrResponse<any>> | IrResponse<any>) => void,
+  resolve: (value: PromiseLike<IrResponse> | IrResponse) => void,
   method: string,
   url: string | undefined,
   config: IrRequestConfig
 ) {
   if (onUploadProgress) {
-    let totalBytesToUpload = 0; // 上传的总字节数
-
-    if (data instanceof File) {
-      totalBytesToUpload = data.size;
-    }
-    if (data instanceof FormData) {
-      data.forEach(value => {
-        if (value instanceof Blob) {
-          totalBytesToUpload += value.size;
-        }
-      });
-    }
-
     const handleUploadProgress = () => {
       const xhr = new XMLHttpRequest();
       let loadedBytes = 0;
@@ -82,7 +69,8 @@ function processUploadProgress(
                 parsedText = xhr.responseText;
             }
           } catch (e) {
-            const responseData = {
+            const responseData: IrResponse = {
+              type: 'default',
               data: parsedText,
               status: xhr.status,
               statusText: xhr.statusText,
@@ -94,6 +82,7 @@ function processUploadProgress(
             reject(error);
           }
           const response: IrResponse = {
+            type: 'default',
             data: parsedText,
             status: xhr.status,
             statusText: xhr.statusText,

--- a/packages/inula-request/src/types/interfaces.ts
+++ b/packages/inula-request/src/types/interfaces.ts
@@ -63,6 +63,9 @@ export interface IrRequestConfig {
 
   // 自定义解析请求参数
   paramsSerializer?: ParamsSerializer;
+
+  // fetch选项
+  fetchOption?: Pick<RequestInit, 'redirect' | 'priority' | 'keepalive' | 'referrer' | 'integrity'>;
 }
 
 interface ParamsSerializer {
@@ -82,6 +85,9 @@ export interface TransitionalOptions {
 
 // 请求响应
 export type IrResponse<T = any> = {
+  // 相应类型
+  type: Response['type'];
+
   // 响应数据
   data: T;
 

--- a/packages/inula-router/package.json
+++ b/packages/inula-router/package.json
@@ -36,7 +36,7 @@
     "redux": "4.2.1"
   },
   "peerDependencies": {
-    "openinula": ">=0.0.10"
+    "openinula": ">=0.0.1"
   },
   "browserslist": {
     "production": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,10 +121,10 @@ importers:
         version: 17.0.45
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.18.1
-        version: 6.21.0(@typescript-eslint/parser@6.19.1(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1)(typescript@4.9.5)
+        version: 6.21.0(@typescript-eslint/parser@6.19.1(eslint@8.57.1)(typescript@5.5.4))(eslint@8.57.1)(typescript@5.5.4)
       '@typescript-eslint/parser':
         specifier: 6.19.1
-        version: 6.19.1(eslint@8.57.1)(typescript@4.9.5)
+        version: 6.19.1(eslint@8.57.1)(typescript@5.5.4)
       babel-jest:
         specifier: ^29.7.0
         version: 29.7.0(@babel/core@7.23.7)
@@ -148,7 +148,7 @@ importers:
         version: 8.0.3
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@17.0.45)(ts-node@10.9.1(@types/node@17.0.45)(typescript@4.9.5))
+        version: 29.7.0(@types/node@17.0.45)(ts-node@10.9.1(@types/node@17.0.45)(typescript@5.5.4))
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
@@ -166,19 +166,19 @@ importers:
         version: 2.79.2
       rollup-plugin-dts:
         specifier: ^6.1.0
-        version: 6.2.0(rollup@2.79.2)(typescript@4.9.5)
+        version: 6.2.0(rollup@2.79.2)(typescript@5.5.4)
       rollup-plugin-terser:
         specifier: ^7.0.2
         version: 7.0.2(rollup@2.79.2)
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.6(@babel/core@7.23.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.23.7))(jest@29.7.0(@types/node@17.0.45)(ts-node@10.9.1(@types/node@17.0.45)(typescript@4.9.5)))(typescript@4.9.5)
+        version: 29.2.6(@babel/core@7.23.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.23.7))(jest@29.7.0(@types/node@17.0.45)(ts-node@10.9.1(@types/node@17.0.45)(typescript@5.5.4)))(typescript@5.5.4)
       turbo:
         specifier: ^2.4.2
         version: 2.4.4
       typescript:
-        specifier: ^4.9.5
-        version: 4.9.5
+        specifier: ~5.5.4
+        version: 5.5.4
 
   next-packages/compiler/babel-api:
     dependencies:
@@ -2896,51 +2896,61 @@ packages:
     resolution: {integrity: sha512-bvXVU42mOVcF4le6XSjscdXjqx8okv4n5vmwgzcmtvFdifQ5U4dXFYaCB87namDRKlUL9ybVtLQ9ztnawaSzvg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.36.0':
     resolution: {integrity: sha512-JFIQrDJYrxOnyDQGYkqnNBtjDwTgbasdbUiQvcU8JmGDfValfH1lNpng+4FWlhaVIR4KPkeddYjsVVbmJYvDcg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.36.0':
     resolution: {integrity: sha512-KqjYVh3oM1bj//5X7k79PSCZ6CvaVzb7Qs7VMWS+SlWB5M8p3FqufLP9VNp4CazJ0CsPDLwVD9r3vX7Ci4J56A==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.36.0':
     resolution: {integrity: sha512-QiGnhScND+mAAtfHqeT+cB1S9yFnNQ/EwCg5yE3MzoaZZnIV0RV9O5alJAoJKX/sBONVKeZdMfO8QSaWEygMhw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.36.0':
     resolution: {integrity: sha512-1ZPyEDWF8phd4FQtTzMh8FQwqzvIjLsl6/84gzUxnMNFBtExBtpL51H67mV9xipuxl1AEAerRBgBwFNpkw8+Lg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.36.0':
     resolution: {integrity: sha512-VMPMEIUpPFKpPI9GZMhJrtu8rxnp6mJR3ZzQPykq4xc2GmdHj3Q4cA+7avMyegXy4n1v+Qynr9fR88BmyO74tg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.36.0':
     resolution: {integrity: sha512-ttE6ayb/kHwNRJGYLpuAvB7SMtOeQnVXEIpMtAvx3kepFQeowVED0n1K9nAdraHUPJ5hydEMxBpIR7o4nrm8uA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.36.0':
     resolution: {integrity: sha512-4a5gf2jpS0AIe7uBjxDeUMNcFmaRTbNv7NxI5xOCs4lhzsVyGR/0qBXduPnoWf6dGC365saTiwag8hP1imTgag==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.36.0':
     resolution: {integrity: sha512-5KtoW8UWmwFKQ96aQL3LlRXX16IMwyzMq/jSSVIIyAANiE1doaQsx/KRyhAvpHlPjPiSU/AYX/8m+lQ9VToxFQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.36.0':
     resolution: {integrity: sha512-sycrYZPrv2ag4OCvaN5js+f01eoZ2U+RmT5as8vhxiFz+kxwlHrsxOwKPSA8WyS+Wc6Epid9QeI/IkQ9NkgYyQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.36.0':
     resolution: {integrity: sha512-qbqt4N7tokFwwSVlWDsjfoHgviS3n/vZ8LK0h1uLG9TYIRuUTJC88E1xb3LM2iqZ/WTqNQjYrtmtGmrmmawB6A==}
@@ -9469,9 +9479,9 @@ packages:
     engines: {node: '>=4.2.0'}
     hasBin: true
 
-  typescript@4.9.5:
-    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
-    engines: {node: '>=4.2.0'}
+  typescript@5.5.4:
+    resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
+    engines: {node: '>=14.17'}
     hasBin: true
 
   typescript@5.8.2:
@@ -12182,14 +12192,14 @@ snapshots:
       '@commitlint/types': 17.8.1
       '@types/node': 20.5.1
       chalk: 4.1.2
-      cosmiconfig: 8.3.6(typescript@5.8.2)
-      cosmiconfig-typescript-loader: 4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.8.2))(ts-node@10.9.1(@types/node@17.0.45)(typescript@4.9.5))(typescript@5.8.2)
+      cosmiconfig: 8.3.6(typescript@5.5.4)
+      cosmiconfig-typescript-loader: 4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.5.4))(ts-node@10.9.1(@types/node@17.0.45)(typescript@5.5.4))(typescript@5.5.4)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
       resolve-from: 5.0.0
-      ts-node: 10.9.1(@types/node@20.5.1)(typescript@5.8.2)
-      typescript: 5.8.2
+      ts-node: 10.9.1(@types/node@20.5.1)(typescript@5.5.4)
+      typescript: 5.5.4
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -12669,7 +12679,7 @@ snapshots:
       - ts-node
       - utf-8-validate
 
-  '@jest/core@29.7.0(ts-node@10.9.1(@types/node@17.0.45)(typescript@4.9.5))':
+  '@jest/core@29.7.0(ts-node@10.9.1(@types/node@17.0.45)(typescript@5.5.4))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -12683,7 +12693,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@18.19.80)(ts-node@10.9.1(@types/node@17.0.45)(typescript@4.9.5))
+      jest-config: 29.7.0(@types/node@18.19.80)(ts-node@10.9.1(@types/node@17.0.45)(typescript@5.5.4))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -13793,13 +13803,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.19.1(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1)(typescript@4.9.5)':
+  '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.19.1(eslint@8.57.1)(typescript@5.5.4))(eslint@8.57.1)(typescript@5.5.4)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 6.19.1(eslint@8.57.1)(typescript@4.9.5)
+      '@typescript-eslint/parser': 6.19.1(eslint@8.57.1)(typescript@5.5.4)
       '@typescript-eslint/scope-manager': 6.21.0
-      '@typescript-eslint/type-utils': 6.21.0(eslint@8.57.1)(typescript@4.9.5)
-      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1)(typescript@4.9.5)
+      '@typescript-eslint/type-utils': 6.21.0(eslint@8.57.1)(typescript@5.5.4)
+      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1)(typescript@5.5.4)
       '@typescript-eslint/visitor-keys': 6.21.0
       debug: 4.4.0(supports-color@5.5.0)
       eslint: 8.57.1
@@ -13807,9 +13817,9 @@ snapshots:
       ignore: 5.3.2
       natural-compare: 1.4.0
       semver: 7.7.1
-      ts-api-utils: 1.4.3(typescript@4.9.5)
+      ts-api-utils: 1.4.3(typescript@5.5.4)
     optionalDependencies:
-      typescript: 4.9.5
+      typescript: 5.5.4
     transitivePeerDependencies:
       - supports-color
 
@@ -13852,16 +13862,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@6.19.1(eslint@8.57.1)(typescript@4.9.5)':
+  '@typescript-eslint/parser@6.19.1(eslint@8.57.1)(typescript@5.5.4)':
     dependencies:
       '@typescript-eslint/scope-manager': 6.19.1
       '@typescript-eslint/types': 6.19.1
-      '@typescript-eslint/typescript-estree': 6.19.1(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 6.19.1(typescript@5.5.4)
       '@typescript-eslint/visitor-keys': 6.19.1
       debug: 4.4.0(supports-color@5.5.0)
       eslint: 8.57.1
     optionalDependencies:
-      typescript: 4.9.5
+      typescript: 5.5.4
     transitivePeerDependencies:
       - supports-color
 
@@ -13880,15 +13890,15 @@ snapshots:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
 
-  '@typescript-eslint/type-utils@6.21.0(eslint@8.57.1)(typescript@4.9.5)':
+  '@typescript-eslint/type-utils@6.21.0(eslint@8.57.1)(typescript@5.5.4)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 6.21.0(typescript@4.9.5)
-      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1)(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.5.4)
+      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1)(typescript@5.5.4)
       debug: 4.4.0(supports-color@5.5.0)
       eslint: 8.57.1
-      ts-api-utils: 1.4.3(typescript@4.9.5)
+      ts-api-utils: 1.4.3(typescript@5.5.4)
     optionalDependencies:
-      typescript: 4.9.5
+      typescript: 5.5.4
     transitivePeerDependencies:
       - supports-color
 
@@ -13918,7 +13928,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@6.19.1(typescript@4.9.5)':
+  '@typescript-eslint/typescript-estree@6.19.1(typescript@5.5.4)':
     dependencies:
       '@typescript-eslint/types': 6.19.1
       '@typescript-eslint/visitor-keys': 6.19.1
@@ -13927,13 +13937,13 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.3
       semver: 7.7.1
-      ts-api-utils: 1.4.3(typescript@4.9.5)
+      ts-api-utils: 1.4.3(typescript@5.5.4)
     optionalDependencies:
-      typescript: 4.9.5
+      typescript: 5.5.4
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@6.21.0(typescript@4.9.5)':
+  '@typescript-eslint/typescript-estree@6.21.0(typescript@5.5.4)':
     dependencies:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
@@ -13942,20 +13952,20 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.3
       semver: 7.7.1
-      ts-api-utils: 1.4.3(typescript@4.9.5)
+      ts-api-utils: 1.4.3(typescript@5.5.4)
     optionalDependencies:
-      typescript: 4.9.5
+      typescript: 5.5.4
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@6.21.0(eslint@8.57.1)(typescript@4.9.5)':
+  '@typescript-eslint/utils@6.21.0(eslint@8.57.1)(typescript@5.5.4)':
     dependencies:
       '@eslint-community/eslint-utils': 4.5.1(eslint@8.57.1)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.5.8
       '@typescript-eslint/scope-manager': 6.21.0
       '@typescript-eslint/types': 6.21.0
-      '@typescript-eslint/typescript-estree': 6.21.0(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.5.4)
       eslint: 8.57.1
       semver: 7.7.1
     transitivePeerDependencies:
@@ -15577,21 +15587,21 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  cosmiconfig-typescript-loader@4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.8.2))(ts-node@10.9.1(@types/node@17.0.45)(typescript@4.9.5))(typescript@5.8.2):
+  cosmiconfig-typescript-loader@4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.5.4))(ts-node@10.9.1(@types/node@17.0.45)(typescript@5.5.4))(typescript@5.5.4):
     dependencies:
       '@types/node': 20.5.1
-      cosmiconfig: 8.3.6(typescript@5.8.2)
-      ts-node: 10.9.1(@types/node@20.5.1)(typescript@5.8.2)
-      typescript: 5.8.2
+      cosmiconfig: 8.3.6(typescript@5.5.4)
+      ts-node: 10.9.1(@types/node@20.5.1)(typescript@5.5.4)
+      typescript: 5.5.4
 
-  cosmiconfig@8.3.6(typescript@5.8.2):
+  cosmiconfig@8.3.6(typescript@5.5.4):
     dependencies:
       import-fresh: 3.3.1
       js-yaml: 4.1.0
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
-      typescript: 5.8.2
+      typescript: 5.5.4
 
   create-ecdh@4.0.4:
     dependencies:
@@ -15615,13 +15625,13 @@ snapshots:
       safe-buffer: 5.2.1
       sha.js: 2.4.11
 
-  create-jest@29.7.0(@types/node@17.0.45)(ts-node@10.9.1(@types/node@17.0.45)(typescript@4.9.5)):
+  create-jest@29.7.0(@types/node@17.0.45)(ts-node@10.9.1(@types/node@17.0.45)(typescript@5.5.4)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@17.0.45)(ts-node@10.9.1(@types/node@17.0.45)(typescript@4.9.5))
+      jest-config: 29.7.0(@types/node@17.0.45)(ts-node@10.9.1(@types/node@17.0.45)(typescript@5.5.4))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -17795,16 +17805,16 @@ snapshots:
       - ts-node
       - utf-8-validate
 
-  jest-cli@29.7.0(@types/node@17.0.45)(ts-node@10.9.1(@types/node@17.0.45)(typescript@4.9.5)):
+  jest-cli@29.7.0(@types/node@17.0.45)(ts-node@10.9.1(@types/node@17.0.45)(typescript@5.5.4)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.1(@types/node@17.0.45)(typescript@4.9.5))
+      '@jest/core': 29.7.0(ts-node@10.9.1(@types/node@17.0.45)(typescript@5.5.4))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@17.0.45)(ts-node@10.9.1(@types/node@17.0.45)(typescript@4.9.5))
+      create-jest: 29.7.0(@types/node@17.0.45)(ts-node@10.9.1(@types/node@17.0.45)(typescript@5.5.4))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@17.0.45)(ts-node@10.9.1(@types/node@17.0.45)(typescript@4.9.5))
+      jest-config: 29.7.0(@types/node@17.0.45)(ts-node@10.9.1(@types/node@17.0.45)(typescript@5.5.4))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -17848,7 +17858,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  jest-config@29.7.0(@types/node@17.0.45)(ts-node@10.9.1(@types/node@17.0.45)(typescript@4.9.5)):
+  jest-config@29.7.0(@types/node@17.0.45)(ts-node@10.9.1(@types/node@17.0.45)(typescript@5.5.4)):
     dependencies:
       '@babel/core': 7.23.7
       '@jest/test-sequencer': 29.7.0
@@ -17874,12 +17884,12 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 17.0.45
-      ts-node: 10.9.1(@types/node@20.5.1)(typescript@5.8.2)
+      ts-node: 10.9.1(@types/node@20.5.1)(typescript@5.5.4)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@18.19.80)(ts-node@10.9.1(@types/node@17.0.45)(typescript@4.9.5)):
+  jest-config@29.7.0(@types/node@18.19.80)(ts-node@10.9.1(@types/node@17.0.45)(typescript@5.5.4)):
     dependencies:
       '@babel/core': 7.23.7
       '@jest/test-sequencer': 29.7.0
@@ -17905,7 +17915,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 18.19.80
-      ts-node: 10.9.1(@types/node@20.5.1)(typescript@5.8.2)
+      ts-node: 10.9.1(@types/node@20.5.1)(typescript@5.5.4)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -18435,12 +18445,12 @@ snapshots:
       - ts-node
       - utf-8-validate
 
-  jest@29.7.0(@types/node@17.0.45)(ts-node@10.9.1(@types/node@17.0.45)(typescript@4.9.5)):
+  jest@29.7.0(@types/node@17.0.45)(ts-node@10.9.1(@types/node@17.0.45)(typescript@5.5.4)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.1(@types/node@17.0.45)(typescript@4.9.5))
+      '@jest/core': 29.7.0(ts-node@10.9.1(@types/node@17.0.45)(typescript@5.5.4))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@17.0.45)(ts-node@10.9.1(@types/node@17.0.45)(typescript@4.9.5))
+      jest-cli: 29.7.0(@types/node@17.0.45)(ts-node@10.9.1(@types/node@17.0.45)(typescript@5.5.4))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -20480,11 +20490,11 @@ snapshots:
       rollup: 3.29.5
       rollup-pluginutils: 2.8.2
 
-  rollup-plugin-dts@6.2.0(rollup@2.79.2)(typescript@4.9.5):
+  rollup-plugin-dts@6.2.0(rollup@2.79.2)(typescript@5.5.4):
     dependencies:
       magic-string: 0.30.17
       rollup: 2.79.2
-      typescript: 4.9.5
+      typescript: 5.5.4
     optionalDependencies:
       '@babel/code-frame': 7.26.2
 
@@ -21450,9 +21460,9 @@ snapshots:
 
   trim-newlines@3.0.1: {}
 
-  ts-api-utils@1.4.3(typescript@4.9.5):
+  ts-api-utils@1.4.3(typescript@5.5.4):
     dependencies:
-      typescript: 4.9.5
+      typescript: 5.5.4
 
   ts-interface-checker@0.1.13: {}
 
@@ -21473,18 +21483,18 @@ snapshots:
       '@types/jest': 27.4.1
       babel-jest: 27.5.1(@babel/core@7.23.7)
 
-  ts-jest@29.2.6(@babel/core@7.23.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.23.7))(jest@29.7.0(@types/node@17.0.45)(ts-node@10.9.1(@types/node@17.0.45)(typescript@4.9.5)))(typescript@4.9.5):
+  ts-jest@29.2.6(@babel/core@7.23.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.23.7))(jest@29.7.0(@types/node@17.0.45)(ts-node@10.9.1(@types/node@17.0.45)(typescript@5.5.4)))(typescript@5.5.4):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@17.0.45)(ts-node@10.9.1(@types/node@17.0.45)(typescript@4.9.5))
+      jest: 29.7.0(@types/node@17.0.45)(ts-node@10.9.1(@types/node@17.0.45)(typescript@5.5.4))
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.7.1
-      typescript: 4.9.5
+      typescript: 5.5.4
       yargs-parser: 21.1.1
     optionalDependencies:
       '@babel/core': 7.23.7
@@ -21549,7 +21559,7 @@ snapshots:
       yn: 3.1.1
     optional: true
 
-  ts-node@10.9.1(@types/node@20.5.1)(typescript@5.8.2):
+  ts-node@10.9.1(@types/node@20.5.1)(typescript@5.5.4):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -21563,7 +21573,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.8.2
+      typescript: 5.5.4
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
@@ -21817,7 +21827,7 @@ snapshots:
 
   typescript@4.2.3: {}
 
-  typescript@4.9.5: {}
+  typescript@5.5.4: {}
 
   typescript@5.8.2: {}
 


### PR DESCRIPTION
feat: inula-request add redirect support; tweak openinula peerDependencies version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for additional fetch-specific options (`redirect`, `priority`, `keepalive`, `referrer`, `integrity`) in request configurations.
  - Response objects now include a `type` property reflecting the response type.

- **Bug Fixes**
  - Corrected header key iteration to ensure proper handling of headers during requests.

- **Chores**
  - Broadened peer dependency version requirements for "openinula" in multiple packages to allow compatibility with older versions.
  - Updated TypeScript development dependency to version 5.5.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->