### PR TITLE
fix(horizon-intl): formatMessage输出不符合预期

### DIFF
--- a/packages/inula-intl/src/format/getFormatMessage.ts
+++ b/packages/inula-intl/src/format/getFormatMessage.ts
@@ -60,6 +60,11 @@ export function getFormatMessage(
     compliedMessage = i18n.messages[id] || messages || id;
   }
 
+  // 如果消息是纯字符串且不需要填充参数，则直接移除占位符两边的单引号
+  if (Object.keys(values).length === 0 && compliedMessage && typeof compliedMessage === 'string') {
+    return compliedMessage.replace(/'{(.*?)}'/gi, '{$1}');
+  }
+
   // 对解析的message进行parse解析，并输出解析后的Token
   compliedMessage = typeof compliedMessage === 'string' ? utils.compile(compliedMessage) : compliedMessage;
 

--- a/packages/inula-intl/tests/core/I18n.test.tsx
+++ b/packages/inula-intl/tests/core/I18n.test.tsx
@@ -104,7 +104,7 @@ describe('I18n', () => {
       locale: 'es',
       messages: { es: messages },
     });
-    expect(i18n.formatMessage("My ''name'' is '{name}'")).toEqual("Mi ''nombre'' es '{name}'");
+    expect(i18n.formatMessage("My ''name'' is '{name}'")).toEqual("Mi ''nombre'' es {name}");
   });
 
   it('._ should format message from catalog', function () {
@@ -133,16 +133,31 @@ describe('I18n', () => {
     expect(i18n.formatMessage({ id: 'id' }, { name: value })).toEqual('hello, <strong>Jane</strong>');
   });
 
-  it('test demo from product', () => {
+  it('test for Message without curly brackets in single quote', () => {
     const messages = {
-      id: "服务商名称长度不能超过64个字符，允许输入中文、字母、数字、字符_-!@#$^.+'}{'，且不能为关键字null(不区分大小写)。",
+      'i18n.key':
+        "服务商名称长度不能超过64个字符，允许输入中文、字母、数字、字符_-!@#$^.+'}{'，且不能为关键字null(不区分大小写)。",
     };
     const i18n = new I18n({
       locale: 'zh',
       messages: { zh: messages },
     });
-    expect(i18n.formatMessage('id')).toEqual(
+    expect(i18n.formatMessage('i18n.key')).toEqual(
       "服务商名称长度不能超过64个字符，允许输入中文、字母、数字、字符_-!@#$^.+'}{'，且不能为关键字null(不区分大小写)。"
+    );
+  });
+
+  it('test for Message with curly brackets in single quote', () => {
+    const messages = {
+      'i18n.key':
+        "服务商名称长度不能超过64个字符，允许输入中文、字母、数字、字符_-!@#$^.+'{}'，且不能为关键字null(不区分大小写)。",
+    };
+    const i18n = new I18n({
+      locale: 'zh',
+      messages: { zh: messages },
+    });
+    expect(i18n.formatMessage('i18n.key')).toEqual(
+      '服务商名称长度不能超过64个字符，允许输入中文、字母、数字、字符_-!@#$^.+{}，且不能为关键字null(不区分大小写)。'
     );
   });
 
@@ -277,7 +292,7 @@ describe('I18n', () => {
       messages: message,
     });
     const messageResult = i18n.formatMessage(
-      { id: `threats.eventMgr.common.loadingTipMore` },
+      { id: 'threats.eventMgr.common.loadingTipMore' },
       { num: 100, total: 29639 }
     );
     expect(messageResult).toEqual('Loaded records: 100, total records: 29,639, pull down to load more...');


### PR DESCRIPTION
修复formatMessage输出不符合预期

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved message formatting to remove unnecessary single quotes around placeholders when no dynamic values are provided.

- **Tests**
  - Updated and added test cases to verify correct handling of single quotes and placeholders in formatted messages, including scenarios with Chinese text and special characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->