### PR TITLE
fix(horizonx): 提供Computed对象可以取到原始对象的方法

### DIFF
--- a/packages/inula/src/inulax/CommonUtils.ts
+++ b/packages/inula/src/inulax/CommonUtils.ts
@@ -79,10 +79,6 @@ export function isSame(obj1: unknown, obj2: unknown) {
   if (obj1 === null || obj1 === undefined || obj2 === null || obj2 === undefined) {
     return obj1 === obj2;
   }
-  // 如果两个对象都是基本类型，比较它们的值是否相等
-  if (kindOf(obj1) !== 'object') {
-    return obj1 === obj2;
-  }
   // 如果两个对象都是数组，比较它们的长度是否相等，然后递归比较每个元素是否相等
   if (Array.isArray(obj1) && Array.isArray(obj2)) {
     if (obj1.length !== obj2.length) {
@@ -94,6 +90,10 @@ export function isSame(obj1: unknown, obj2: unknown) {
       }
     }
     return true;
+  }
+  // 如果两个对象都是基本类型，比较它们的值是否相等
+  if (kindOf(obj1) !== 'object') {
+    return obj1 === obj2;
   }
   // 如果两个对象都是普通对象，比较它们的属性数量是否相等，然后递归比较每个属性的值是否相等
   if (kindOf(obj1) === 'object') {

--- a/packages/inula/src/inulax/proxy/readonlyProxy.ts
+++ b/packages/inula/src/inulax/proxy/readonlyProxy.ts
@@ -14,10 +14,14 @@
  */
 
 import { isObject } from '../CommonUtils';
+import { RAW_VALUE } from '../Constants';
 
 export function readonlyProxy<T extends Record<string, any>>(rawObj: T): ProxyHandler<T> {
   return new Proxy(rawObj, {
     get(rawObj, property, receiver) {
+      if (property === RAW_VALUE) {
+        return rawObj;
+      }
       const result = Reflect.get(rawObj, property, receiver);
 
       try {


### PR DESCRIPTION
fix(horizonx): 提供Computed对象可以取到原始对象的方法

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Accessing a special property now returns the original raw object when using readonly proxies.

- **Refactor**
  - Improved the order of type checks for value comparison, ensuring array checks occur before primitive type checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->