### PR TITLE
bugfix: export Action type

### DIFF
--- a/packages/inula/src/index.ts
+++ b/packages/inula/src/index.ts
@@ -57,6 +57,7 @@ import {
   isPortal,
 } from './external/InulaIs';
 import { createStore, useStore, clearStore } from './inulax/store/StoreHandler';
+import { Action } from './inulax/types';
 import * as reduxAdapter from './inulax/adapters/redux';
 import { watch } from './inulax/proxy/watch';
 import { act } from './external/TestUtil';
@@ -163,6 +164,7 @@ export {
   reduxAdapter,
   watch,
   toRaw,
+  Action,
   // 兼容ReactIs
   isFragment,
   isElement,

--- a/packages/inula/src/inulax/types.ts
+++ b/packages/inula/src/inulax/types.ts
@@ -59,7 +59,7 @@ export type StoreActions<S extends Record<string, unknown>, A extends UserAction
   [K in keyof A]: Action<A[K], S>;
 };
 
-type Action<T extends ActionFunction<any>, S extends Record<string, unknown>> = (
+export type Action<T extends ActionFunction<any>, S extends Record<string, unknown>> = (
   this: StoreObj<S, any, any>,
   ...args: RemoveFirstFromTuple<Parameters<T>>
 ) => ReturnType<T>;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Exposed a new public API: Action is now available as a named export and via the Inula namespace.
  - Enables direct importing of Action from the package and access as Inula.Action for improved type usage.
  - No functional or runtime behavior changes; this is an API surface expansion.
  - Existing code remains compatible; projects can opt in to the new export without modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->