### PR TITLE
fix: export Action type

### DIFF
--- a/.changeset/twelve-cobras-tie.md
+++ b/.changeset/twelve-cobras-tie.md
@@ -1,0 +1,5 @@
+---
+"openinula": patch
+---
+
+fix: export Action type

--- a/packages/inula/src/index.ts
+++ b/packages/inula/src/index.ts
@@ -57,6 +57,7 @@ import {
   isPortal,
 } from './external/InulaIs';
 import { createStore, useStore, clearStore } from './inulax/store/StoreHandler';
+import type { Action } from './inulax/types';
 import * as reduxAdapter from './inulax/adapters/redux';
 import { watch } from './inulax/proxy/watch';
 import { act } from './external/TestUtil';
@@ -163,6 +164,7 @@ export {
   reduxAdapter,
   watch,
   toRaw,
+  type Action,
   // 兼容ReactIs
   isFragment,
   isElement,

--- a/packages/inula/src/inulax/types.ts
+++ b/packages/inula/src/inulax/types.ts
@@ -59,7 +59,7 @@ export type StoreActions<S extends Record<string, unknown>, A extends UserAction
   [K in keyof A]: Action<A[K], S>;
 };
 
-type Action<T extends ActionFunction<any>, S extends Record<string, unknown>> = (
+export type Action<T extends ActionFunction<any>, S extends Record<string, unknown>> = (
   this: StoreObj<S, any, any>,
   ...args: RemoveFirstFromTuple<Parameters<T>>
 ) => ReturnType<T>;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Exposed the Action type in the public API, allowing consumers to import and use it for stronger typing in their applications. This is a type-only addition with no runtime impact.

- **Chores**
  - Added a changeset to record the patch release reflecting the public API update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->